### PR TITLE
Fix user retrieval logic

### DIFF
--- a/Berx3.Api/Controllers/UsersController.cs
+++ b/Berx3.Api/Controllers/UsersController.cs
@@ -26,7 +26,7 @@ namespace Berx3.Api.Controllers
         {
             var user = await _userRepository.GetByIdAsync(id);
             if (user == null)
-                NotFound();
+                return NotFound();
 
             return Ok(user);
         }

--- a/Berx3.Api/Repositories/UserRepository.cs
+++ b/Berx3.Api/Repositories/UserRepository.cs
@@ -19,7 +19,9 @@ namespace Berx3.Api.Repositories
             
 
         public async Task<IEnumerable<User>> GetAllAsync()
-            => await _context.Users.ToListAsync();
+            => await _context.Users
+                .Where(u => u.IsActive)
+                .ToListAsync();
 
         public async Task<User?> GetByIdAsync(int id)
             => await _context.Users.FindAsync(id);


### PR DESCRIPTION
## Summary
- filter users by active status in `UserRepository`
- ensure `UsersController.GetUserById` returns `NotFound`

## Testing
- `dotnet test Berx3.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e41da80f8833189f19cd8d258852a